### PR TITLE
Update jd-cli version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,8 +7,6 @@ RUN apt-get update && apt-get install -y \
     unzip \
     p7zip-full;
 
-ENV JD_VERSION "1.4.0"
-#ENV JD_VERSION "1.6.6"
 ENV JD_CLI_VERSION "0.9.1.Final"
 # ENV JD_CLI_VERSION "1.0.1.Final"
 
@@ -21,9 +19,6 @@ RUN wget -q -O "dex2jar-2.1.zip" https://github.com/pxb1988/dex2jar/files/186756
     && chmod u+x dex-tools-2.1-SNAPSHOT/*.sh \
     && rm -f dex2jar-2.1.zip
 ENV PATH $PATH:/opt/dex-tools-2.1-SNAPSHOT
-
-# JD-GUI
-RUN wget -q -O "jd-gui.jar" "https://github.com/java-decompiler/jd-gui/releases/download/v$JD_VERSION/jd-gui-$JD_VERSION.jar"
 
 # JD-CLI
 RUN wget -q -O "jd-cli.zip" "https://github.com/kwart/jd-cmd/releases/download/jd-cmd-$JD_CLI_VERSION/jd-cli-$JD_CLI_VERSION-dist.zip"

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,8 +7,7 @@ RUN apt-get update && apt-get install -y \
     unzip \
     p7zip-full;
 
-ENV JD_CLI_VERSION "0.9.1.Final"
-# ENV JD_CLI_VERSION "1.0.1.Final"
+ENV JD_CLI_VERSION "1.0.1.Final"
 
 RUN mkdir -p /opt
 WORKDIR /opt

--- a/extract.sh
+++ b/extract.sh
@@ -1,9 +1,9 @@
 #!/bin/sh
 
-# check that 7z is installed
+# Verify that 7z is installed
 command -v 7z >/dev/null 2>&1 || { echo >&2 "This script requires 7z.  Aborting."; exit 1; }
 
-jdgui="/opt/jd-cli"
+jd="/opt/jd-cli"
 dex2jar="/opt/dex-tools-2.1-SNAPSHOT/d2j-dex2jar.sh"
 
 if [ $# -eq 0 ]
@@ -12,25 +12,20 @@ if [ $# -eq 0 ]
     exit 1
 fi
 
-# extracting the apk
+# Extract the apk
 echo "apk file: $1"
 DIRECTORY=$(dirname ${1})
 FILE=$(basename ${1})
 
-echo "Creating directory $FILE.files"
-# echo "mkdir $1.files"
+echo "[7z] Extracting apk files to: $1.files/"
 mkdir $1.files
-
-echo "Extracting apk to $1.files/"
 7z x $1 -o$1.files/
 
-echo "Generating $FILE.jar in $1.files/"
-# echo "$dex2jar $dexfile -o $1.files/$FILE.jar"
+echo "[dex2jar] Creating temporary .jar file"
 $dex2jar $1 -o $FILE.jar
 
-echo "Opening jd-gui with .jar file"
-# echo "$jdgui $1.files/$FILE.jar"
-$jdgui -od $1.src $FILE.jar 2> /dev/null
+echo "[jd-cli] Extracting source files to: $1.src/"
+$jd --outputDir $1.src $FILE.jar 2> /dev/null
 
-echo "Removing created .jar file"
+echo "Removing temporary .jar file"
 rm $FILE.jar


### PR DESCRIPTION
I ran into a weird bug where the jd-cli would not extract any source files from the JAR. Updating to the latest version of jd-cli fixed the issue.